### PR TITLE
Added IdleHint dbus screenlock event

### DIFF
--- a/internal/linux/power/screenLock.go
+++ b/internal/linux/power/screenLock.go
@@ -65,6 +65,9 @@ func ScreenLockUpdater(ctx context.Context) chan tracker.Sensor {
 				if v, ok := props["LockedHint"]; ok {
 					sensorCh <- newScreenlockEvent(dbusx.VariantToValue[bool](v))
 				}
+				if v, ok := props["IdleHint"]; ok {
+					sensorCh <- newScreenlockEvent(dbusx.VariantToValue[bool](v))
+				}
 			case "org.freedesktop.login1.Session.Lock":
 				sensorCh <- newScreenlockEvent(true)
 			case "org.freedesktop.login1.Session.Unlock":


### PR DESCRIPTION
On my system (Arch Linux + Cinnamon Desktop Enviroment) the event emitted by screenlocks is called `IdleHint`, therefore I added it to the screenlock dbus handler.


Raw output from `dbus-monitor --system "type='signal',interface='org.freedesktop.DBus.Properties',path_namespace='/org/freedesktop/login1/session'"` looks like this:

```
   string "org.freedesktop.login1.Session"
   array [
      dict entry(
         string "IdleHint"
         variant             boolean true
      )
      dict entry(
         string "IdleSinceHint"
         variant             uint64 1705872369067393
      )
      dict entry(
         string "IdleSinceHintMonotonic"
         variant             uint64 299258857661
      )
   ]
   array [
   ]
```