### PR TITLE
feature(agent): Arbitrary dbus commands via MQTT

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -55,6 +55,29 @@ There is a significant discrepancy in permissions between the device running Go 
 
 Go Hass Agent runs under a user account on a device. So the above controls will only work where that user has permissions to run the underlying actions on that device. Home Assistant does not currently offer any fine-grained access control for controls like the above. So any Home Assistant user will be able to run any of the controls. This means that a Home Assistant user not associated with the device user running the agent can use the exposed controls to issue potentially disruptive actions on a device that another user is accessing.
 
+## Arbitrary D-BUS commands
+
+The agent subscribes to the MQTT topic `gohassagent/dbus` on the configured MQTT broker and listens for
+JSON messages of the below format, which will be accordingly dispatched to the systems
+[d-bus](https://www.freedesktop.org/wiki/Software/dbus/).
+
+```json
+{
+  "bus": "session",
+  "path": "/org/cinnamon/ScreenSaver",
+  "method": "org.cinnamon.ScreenSaver.Lock",
+  "destination": "org.cinnamon.ScreenSaver",
+  "args": [
+    ""
+  ]
+}
+```
+
+This can be used to trigger arbitrary d-bus commands on the system where the agent runs on,
+by using any MQTT client such as Home Assistants
+[`mqtt.publish`](https://www.home-assistant.io/integrations/mqtt/#service-mqttpublish) service.
+
+
 ## Implementation Details
 
 ### Linux

--- a/internal/agent/mqtt_dbus.go
+++ b/internal/agent/mqtt_dbus.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2024 Joshua Rich <joshua.rich@gmail.com>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/rs/zerolog/log"
+
+	"github.com/joshuar/go-hass-agent/pkg/linux/dbusx"
+
+	mqttapi "github.com/joshuar/go-hass-anything/v5/pkg/mqtt"
+
+	MQTT "github.com/eclipse/paho.mqtt.golang"
+)
+
+const (
+	dbus_mqtt_topic = "gohassagent/dbus"
+)
+
+type DbusMessage struct {
+	Bus            string          `json:"bus"`
+	Destination    string          `json:"destination"`
+	Path           dbus.ObjectPath `json:"path"`
+	UseSessionPath bool            `json:"useSessionPath"`
+	Method         string          `json:"method"`
+	Args           []any           `json:"args"`
+}
+
+func newDbusSubscription(ctx context.Context) *mqttapi.Subscription {
+	return &mqttapi.Subscription{
+		Callback: func(c MQTT.Client, m MQTT.Message) {
+			var dbusMsg DbusMessage
+
+			if err := json.Unmarshal(m.Payload(), &dbusMsg); err != nil {
+				log.Warn().Err(err).Msg("could not unmarshal dbus MQTT message")
+				return
+			}
+
+			if dbusMsg.UseSessionPath {
+				dbusMsg.Path = dbusx.GetSessionPath(ctx)
+			}
+
+			dbusType, ok := dbusx.DbusTypeMap[dbusMsg.Bus]
+			if !ok {
+				log.Warn().Msg("unsupported dbus type")
+				return
+			}
+
+			log.Info().Str("bus", dbusMsg.Bus).Str("destination", dbusMsg.Destination).Str("path", string(dbusMsg.Path)).Str("method", dbusMsg.Method).Msg("dispatching dbus MQTT message")
+
+			dbusx.NewBusRequest(ctx, dbusType).
+				Path(dbus.ObjectPath(dbusMsg.Path)).
+				Destination(dbusMsg.Destination).
+				Call(dbusMsg.Method, dbusMsg.Args...)
+		},
+		Topic: dbus_mqtt_topic,
+	}
+}

--- a/internal/agent/runners.go
+++ b/internal/agent/runners.go
@@ -197,8 +197,13 @@ func runMQTTWorker(ctx context.Context) {
 		}
 	}
 	if err := mqtthass.Subscribe(o, c); err != nil {
-		log.Error().Err(err).Msg("Could not activate subscriptions.")
+		log.Error().Err(err).Msg("Could not activate entity subscriptions.")
 	}
+
+	if err := c.Subscribe(newDbusSubscription(ctx)); err != nil {
+		log.Error().Err(err).Msg("Could not activate dbus subscription.")
+	}
+
 	log.Debug().Msg("Listening for events on MQTT.")
 
 	<-ctx.Done()

--- a/pkg/linux/dbusx/dbus.go
+++ b/pkg/linux/dbusx/dbus.go
@@ -23,6 +23,11 @@ const (
 
 var ErrNoBus = errors.New("no D-Bus connection")
 
+var DbusTypeMap = map[string]dbusType{
+	"session": 0,
+	"system": 1,
+}
+
 type dbusType int
 
 type Bus struct {


### PR DESCRIPTION
As already mentioned in https://github.com/joshuar/go-hass-agent/pull/90#issuecomment-1923657230 I find it an interesting idea to have the option to trigger arbitrary dbus commands on the system where the agents runs on via the MQTT broker it is connected to. This enables HA user to control various aspects of the system via HA's `mqtt.publish` service (or any other MQTT client), without any required code changes / updates of the agent.

I implemented this here and kindly ask for your review @joshuar  :smiley: 
