### PR TITLE
fix(linux): :bug: don't include mounts where stats cannot be retrieve…

### DIFF
--- a/internal/linux/disk/usageStats.go
+++ b/internal/linux/disk/usageStats.go
@@ -132,9 +132,9 @@ func getMounts() ([]*mount, error) {
 
 			if err := validmount.getMountInfo(); err != nil {
 				slog.Debug("Error getting mount info.", slog.Any("error", err))
+			} else {
+				mounts = append(mounts, validmount)
 			}
-
-			mounts = append(mounts, validmount)
 		}
 	}
 


### PR DESCRIPTION
…d for disk usage sensors