### PR TITLE
docs: remove references to Fyne

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,6 @@ jobs:
             auth.docker.io:443
             azure.archive.ubuntu.com:80
             esm.ubuntu.com:443
-            fyne.io:443
             github.com:443
             go.dev:443
             go.googlesource.com:443

--- a/.vscode/ltex.dictionary.en-AU.txt
+++ b/.vscode/ltex.dictionary.en-AU.txt
@@ -1,4 +1,3 @@
-Fyne
 Hass
 websocket
 variadic

--- a/README.md
+++ b/README.md
@@ -452,10 +452,7 @@ Packages (and binaries) are available for **amd64**, **arm (v6 and v7)** and
 **arm64** architectures.
 
 For distributions not listed above, you can try the binary, or build it yourself
-from source (see development [docs](#%EF%B8%8F-buildingcompiling-manually)). Note
-that while Go is known for statically compiled binaries that “run anywhere”, the
-Fyne UI toolkit used by Go Hass Agent makes use of shared libraries that may need
-to be installed as well.
+from source (see development [docs](#%EF%B8%8F-buildingcompiling-manually)).
 
 Package signatures can be verified with
 [cosign](https://github.com/sigstore/cosign). To verify a package, you'll need


### PR DESCRIPTION
AFAICT from e0cf4290 and 2b5dbf24, this UI toolkit is not longer used?