### PR TITLE
refactor: remove unnecessary bunx calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "license": "MIT",
   "name": "go-hass-agent",
   "scripts": {
-    "build:js": "bunx esbuild ./web/assets/scripts.js --bundle --sourcemap --outdir=./web/content/",
-    "build:css": "bunx tailwindcss -i ./web/assets/styles.css -o ./web/content/styles.css --minify --map"
+    "build:js": "esbuild ./web/assets/scripts.js --bundle --sourcemap --outdir=./web/content/",
+    "build:css": "tailwindcss -i ./web/assets/styles.css -o ./web/content/styles.css --minify --map"
   },
   "version": "0.0.0"
 }


### PR DESCRIPTION
bunx is not required because npm (and I guess Bun?) automatically fix up $PATH: https://docs.npmjs.com/cli/v10/using-npm/scripts#path

I tested this patch with both Bun and npm.

In particular, this is useful because it allows `package.json` scripts to be used during the build process by users without a Bun toolchain installed. (I plan to file a followup PR recommending `bun run`/`npm run` in the README, since they're significantly easier to read/type/etc.)