### PR TITLE
fix: check disabled preference before D-Bus call in ABRT worker

### DIFF
--- a/platform/linux/system/problems.go
+++ b/platform/linux/system/problems.go
@@ -49,6 +49,21 @@ func NewProblemsWorker(ctx context.Context) (workers.EntityWorker, error) {
 		PollingEntityWorkerData: &workers.PollingEntityWorkerData{},
 	}
 
+	defaultPrefs := &ProblemsPrefs{
+		UpdateInterval: abrtProblemsCheckInterval.String(),
+	}
+
+	var err error
+
+	worker.prefs, err = workers.LoadWorkerPreferences(abrtProblemsPreferencesID, defaultPrefs)
+	if err != nil {
+		return worker, fmt.Errorf("load preferences: %w", err)
+	}
+
+	if worker.prefs.IsDisabled() {
+		return worker, nil
+	}
+
 	var ok bool
 
 	worker.bus, ok = linux.CtxGetSystemBus(ctx)
@@ -56,18 +71,9 @@ func NewProblemsWorker(ctx context.Context) (workers.EntityWorker, error) {
 		return worker, fmt.Errorf("get system bus: %w", linux.ErrNoSystemBus)
 	}
 	// Check if we can fetch problem data, bail if we can't.
-	_, err := dbusx.GetData[[]string](worker.bus, dBusProblemsDest, dBusProblemIntr, dBusProblemIntr+".GetProblems")
+	_, err = dbusx.GetData[[]string](worker.bus, dBusProblemsDest, dBusProblemIntr, dBusProblemIntr+".GetProblems")
 	if err != nil {
 		return worker, fmt.Errorf("get abrt problems: %w", err)
-	}
-
-	defaultPrefs := &ProblemsPrefs{
-		UpdateInterval: abrtProblemsCheckInterval.String(),
-	}
-
-	worker.prefs, err = workers.LoadWorkerPreferences(abrtProblemsPreferencesID, defaultPrefs)
-	if err != nil {
-		return worker, fmt.Errorf("load preferences: %w", err)
 	}
 
 	pollInterval, err := time.ParseDuration(worker.prefs.UpdateInterval)


### PR DESCRIPTION
## Summary

- The ABRT problems worker logs a warning on every startup on non-Fedora/RHEL systems (Arch, Ubuntu, etc.) even when explicitly disabled via `[sensors.system.abrt_problems] disabled = true` in preferences
- Root cause: `NewProblemsWorker()` attempts the D-Bus call to `org.freedesktop.problems.GetProblems` **before** loading user preferences, so the `disabled` flag is never checked when ABRT is unavailable
- Fix: move preference loading and `IsDisabled()` check before the D-Bus connection attempt, returning early with `(worker, nil)` when disabled — matching the established pattern used by `inhibit.go` and `mpris.go`

## Behavior change

| Scenario | Before | After |
|---|---|---|
| ABRT unavailable + `disabled = true` | Warning logged | Silently skipped |
| ABRT unavailable + `disabled = false` (or unset) | Warning logged | Warning logged (unchanged) |
| ABRT available + `disabled = true` | Worker skipped at `StartEntityWorkers` | Worker skipped earlier at init |
| ABRT available + `disabled = false` | Worker runs normally | Worker runs normally (unchanged) |

## Test plan

- [x] Verified on Arch/CachyOS (no ABRT) with `disabled = true` — warning no longer appears
- [x] `go build ./...` compiles without errors
- [x] Traced all downstream code paths — nil `bus`/`Trigger` fields are never dereferenced because `StartEntityWorkers` checks `IsDisabled()` before calling `Start()`