### PR TITLE
fix(linux/disk): respect disabled preference before SMART capability check

### DIFF
--- a/platform/linux/disk/smart.go
+++ b/platform/linux/disk/smart.go
@@ -65,17 +65,22 @@ func NewSmartWorker(_ context.Context) (workers.EntityWorker, error) {
 		PollingEntityWorkerData: &workers.PollingEntityWorkerData{},
 	}
 
-	passed, err := smartWorkerRequiredChecks.Passed()
-	if err != nil || !passed {
-		return worker, fmt.Errorf("check capabilities: %w", err)
-	}
-
 	defaultPrefs := &WorkerPrefs{
 		UpdateInterval: smartWorkerUpdateInterval.String(),
 	}
+	var err error
 	worker.prefs, err = workers.LoadWorkerPreferences(smartWorkerPreferencesID, defaultPrefs)
 	if err != nil {
 		return worker, fmt.Errorf("load preferences: %w", err)
+	}
+
+	if worker.prefs.IsDisabled() {
+		return worker, nil
+	}
+
+	passed, err := smartWorkerRequiredChecks.Passed()
+	if err != nil || !passed {
+		return worker, fmt.Errorf("check capabilities: %w", err)
 	}
 
 	pollInterval, err := time.ParseDuration(worker.prefs.UpdateInterval)


### PR DESCRIPTION
Fixes #908 

NewSmartWorker() ran its capability check before loading worker preferences, and never checked IsDisabled(). This meant a smart_status worker disabled via config still failed the capability check first and logged a "Could not init worker: check capabilities: missing cap_sys_rawio" warning on every startup, even though the feature was never going to run anyway.

Load preferences first and return early (worker, nil) when disabled, matching the pattern used elsewhere (e.g. NewProblemsWorker, NewScreenLockControl), so the manager silently skips disabled workers via IsDisabled() instead of logging a spurious warning.