### PR TITLE
fix(linux): improve capability error clarity and respect disabled pref for activity worker

### DIFF
--- a/platform/linux/checks.go
+++ b/platform/linux/checks.go
@@ -10,6 +10,7 @@ import (
 	"os/user"
 	"slices"
 	"strconv"
+	"strings"
 
 	"kernel.org/pub/linux/libs/security/libcap/cap"
 )
@@ -27,12 +28,13 @@ type Checks struct {
 // Passed will perform all checks and return a boolean indicating whether they passed (true) or failed (false). On
 // failure, on non-nil error will also be returned.
 func (c *Checks) Passed() (bool, error) {
-	groupsOK, err := c.hasGroups()
+	missingGroups, err := c.hasGroups()
 	if err != nil {
 		return false, fmt.Errorf("%w: check for groups: %w", ErrCapChecksFailed, err)
 	}
-	if !groupsOK {
-		return false, fmt.Errorf("%w: missing groups", ErrCapChecksFailed)
+	if len(missingGroups) > 0 {
+		return false, fmt.Errorf("%w: user is not a member of required group(s): %s",
+			ErrCapChecksFailed, strings.Join(missingGroups, ", "))
 	}
 	capsOK, err := c.hasCapabilities()
 	if err != nil {
@@ -44,22 +46,25 @@ func (c *Checks) Passed() (bool, error) {
 	return true, nil
 }
 
-// hasGroups returns a boolean indicating whether Go Hass Agent is running with the required group permissions.
-func (c *Checks) hasGroups() (bool, error) {
+// hasGroups returns the names of any required groups that Go Hass Agent is
+// not currently running with. An empty slice indicates all required groups
+// are present.
+func (c *Checks) hasGroups() ([]string, error) {
 	gids, err := os.Getgroups()
 	if err != nil {
-		return false, fmt.Errorf("could not determine groups: %w", err)
+		return nil, fmt.Errorf("could not determine groups: %w", err)
 	}
+	var missing []string
 	for group := range slices.Values(c.Groups) {
 		gid, err := strconv.Atoi(group.Gid)
 		if err != nil {
-			return false, fmt.Errorf("convert gid: %w", err)
+			return nil, fmt.Errorf("convert gid: %w", err)
 		}
 		if !slices.Contains(gids, gid) {
-			return false, nil
+			missing = append(missing, group.Name)
 		}
 	}
-	return true, nil
+	return missing, nil
 }
 
 // hasCapabilities returns a boolean indicating whether Go Hass Agent has the required capabilties set.

--- a/platform/linux/system/activity.go
+++ b/platform/linux/system/activity.go
@@ -51,6 +51,20 @@ func NewUserActivitySensor(ctx context.Context) (workers.EntityWorker, error) {
 		activity:       make(chan bool, 1),
 	}
 
+	// Load worker preferences.
+	defaultPrefs := &activityWorkerPrefs{
+		IdleTimeout: activityWorkerDefaultIdleTimeout.String(),
+	}
+	var err error
+	worker.prefs, err = workers.LoadWorkerPreferences(sensorsPrefPrefix+"app_sensors", defaultPrefs)
+	if err != nil {
+		return worker, fmt.Errorf("load preferences: %w", err)
+	}
+
+	if worker.prefs.IsDisabled() {
+		return worker, nil
+	}
+
 	// Check for required capabilities.
 	group, err := user.LookupGroup("input")
 	if err != nil {
@@ -63,15 +77,6 @@ func NewUserActivitySensor(ctx context.Context) (workers.EntityWorker, error) {
 	passed, err := capabilities.Passed()
 	if err != nil || !passed {
 		return worker, fmt.Errorf("check capabilities: %w", err)
-	}
-
-	// Load worker preferences.
-	defaultPrefs := &activityWorkerPrefs{
-		IdleTimeout: activityWorkerDefaultIdleTimeout.String(),
-	}
-	worker.prefs, err = workers.LoadWorkerPreferences(sensorsPrefPrefix+"app_sensors", defaultPrefs)
-	if err != nil {
-		return worker, fmt.Errorf("load preferences: %w", err)
 	}
 
 	// Get input devices.


### PR DESCRIPTION
Fixes #910

Checks.hasGroups() only returned a bare bool, so a missing group capability check surfaced as a generic "missing groups" error with no indication of which group was actually required. This made the "Could not init worker: check capabilities: ... missing groups" warning for the activity worker hard to act on.

hasGroups() now returns the names of the missing group(s), so Passed() can report e.g. "user is not a member of required group(s): input" instead.

Separately, NewUserActivitySensor() ran its group/capability check before loading worker preferences and never checked IsDisabled(), so a disabled activity worker would still fail the capability check and log the warning. Load preferences first and return early (worker, nil) when disabled, matching the pattern used elsewhere (e.g. NewProblemsWorker, NewScreenLockControl).